### PR TITLE
Support multiple search terms

### DIFF
--- a/bin/npms.js
+++ b/bin/npms.js
@@ -23,7 +23,7 @@ const argv = require('yargs')
       got('https://api.npms.io/search', {
         json: true,
         query: {
-          term: argv._.slice(1),
+          term: argv._.slice(1).join('+'),
           size: argv.number
         }
       }).then(res => {


### PR DESCRIPTION
`npms search ...more... ...than... ...one... ...term...` returns silently. This fixes it.